### PR TITLE
Fix for LD SP,d16 and LD SP,r16 not working properly

### DIFF
--- a/compiler.js
+++ b/compiler.js
@@ -304,7 +304,7 @@ function determineLdType(operand) {
 			return 1;
 		} else {
 			byteStream.push(49);
-			readWord(operand[1]);
+			readWord([operand[1]]);
 			return 3;
 		}
 	} else {


### PR DESCRIPTION
Currently, executing LD SP,d16 throws an "Only one operand expected for readWord!" error. From my limited code knowledge, this seems to be the issue. For those that are reading this before the fix gets deployed, the workaround is loading HL with whatever you need, and then doing LD SP,HL.